### PR TITLE
Update run_cbnftfloorprice.py

### DIFF
--- a/run_cbnftfloorprice.py
+++ b/run_cbnftfloorprice.py
@@ -20,6 +20,10 @@ def main() -> None:
     logging.info("preprocessing")
     nft_trades_df = nft_trades_df[nft_trades_df["price_eth"] > 0]
     nft_trades_df["log_price"] = np.log(nft_trades_df["price_eth"])
+    # New Preprocessing Code
+    nft_trades_df.sort_values(["contract_address", "token_id", "block_number"], inplace=True)
+    nft_trades_df = nft_trades_df.groupby(["contract_address", "token_id"]).tail(1)
+    # End
     nft_trades_df.sort_values(
         ["chain_id", "contract_address", "block_number"], inplace=True
     )


### PR DESCRIPTION
Currently, it is possible for someone to manipulate the oracle price by wash trading to a specific quantile, using the following formula to calculate the cost:

```math
U_w = U_p\cdot(\frac{Q_m}{Q_t} - 1)
```
$U_w =$ Unit Volume To Wash Trade &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  $Q_m =$ Quantile Manipulation Target

$Q_t =$ Quantile Intended Target &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; $U_p =$ Unit Volume of Lookback Period

For example, if an attacker wanted to manipulate the next prediction to correspond to the 10th quantile instead of the 5th quantile, they would need to wash trade a volume equal to the entire lookback period. To reduce the potential for wash trading by a single NFT holder, we introduce a filter that limits the number of sales that a single NFT ID can contribute to a given lookback period. This filter removes duplicate sales of the same NFT ID per contract and only considers the latest transaction.
